### PR TITLE
Fix pointer problem (fixes #28)

### DIFF
--- a/board.go
+++ b/board.go
@@ -146,16 +146,16 @@ func ImageColorConvert(image *BMPImage) *BMPImage {
 }
 
 func closestColor(color Color) *Color {
-	var closestColor *Color
+	var closestColor Color
 	var closestDistance = math.MaxFloat64
 	for _, c := range ActiveColors {
 		distance := euclideanDistance(color, c)
-		if closestDistance == 0 || distance < closestDistance {
+		if distance < closestDistance {
 			closestDistance = distance
-			closestColor = &c
+			closestColor = c
 		}
 	}
-	return closestColor
+	return &closestColor
 }
 
 func hexToRGB(hexColor string) Color {


### PR DESCRIPTION
This hopefully solves the problem with the wrong colors. (fixes #28)

### Cause
The function `closestColor()` uses the variable `c` to iterate over all available colors. When it found a color that is closer than the previous best, it sets `closestColor` to a pointer to `c`. In the end it returns `closestColor` which still is a pointer to `c`. Problem is: `c` has changed by then and always has the value of the last item in the list of colors that was checked.